### PR TITLE
Update gorm.go

### DIFF
--- a/configs/gorm.go
+++ b/configs/gorm.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Base struct {
-	ID        string `gorm:"primaryKey;autoIncrement:false"`
+	ID        string `gorm:"type:varchar(191);primaryKey;autoIncrement:false"`
 	Counter   uint64 `gorm:"index;autoIncrement:true"`
 	CreatedAt sql.NullTime
 	UpdatedAt sql.NullTime


### PR DESCRIPTION
fix error when create foreign key if the Base ID column type was implicitly set by gorm