### PR TITLE
support go test ./tests

### DIFF
--- a/parsers/listener.go
+++ b/parsers/listener.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
+	"regexp"
 
 	"gopkg.in/yaml.v2"
 )
@@ -18,6 +20,10 @@ func (l *Listeners) Parse() []string {
 	workDir, err := os.Getwd()
 	if err != nil {
 		panic(err)
+	}
+
+	if ok, _ := regexp.MatchString(`tests$`, workDir); ok {
+		workDir = path.Dir(workDir)
 	}
 
 	config, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", workDir, LISTENERS_FILE))

--- a/parsers/logger.go
+++ b/parsers/logger.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
+	"regexp"
 
 	"gopkg.in/yaml.v2"
 )
@@ -18,6 +20,10 @@ func (l *Logger) Parse() []string {
 	workDir, err := os.Getwd()
 	if err != nil {
 		panic(err)
+	}
+
+	if ok, _ := regexp.MatchString(`tests$`, workDir); ok {
+		workDir = path.Dir(workDir)
 	}
 
 	config, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", workDir, LOGGERS_FILE))

--- a/parsers/middleware.go
+++ b/parsers/middleware.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
+	"regexp"
 
 	"gopkg.in/yaml.v2"
 )
@@ -18,6 +20,10 @@ func (m *Middleware) Parse() []string {
 	workDir, err := os.Getwd()
 	if err != nil {
 		panic(err)
+	}
+
+	if ok, _ := regexp.MatchString(`tests$`, workDir); ok {
+		workDir = path.Dir(workDir)
 	}
 
 	config, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", workDir, MIDDLEWARES_FILE))

--- a/parsers/module.go
+++ b/parsers/module.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
+	"regexp"
 
 	"gopkg.in/yaml.v2"
 )
@@ -18,6 +20,10 @@ func (m *Module) Parse() []string {
 	workDir, err := os.Getwd()
 	if err != nil {
 		panic(err)
+	}
+
+	if ok, _ := regexp.MatchString(`tests$`, workDir); ok {
+		workDir = path.Dir(workDir)
 	}
 
 	config, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", workDir, MODULES_FILE))

--- a/parsers/route.go
+++ b/parsers/route.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
+	"regexp"
 
 	"gopkg.in/yaml.v2"
 )
@@ -18,6 +20,10 @@ func (r *Route) Parse() []string {
 	workDir, err := os.Getwd()
 	if err != nil {
 		panic(err)
+	}
+
+	if ok, _ := regexp.MatchString(`tests$`, workDir); ok {
+		workDir = path.Dir(workDir)
 	}
 
 	config, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", workDir, ROUTES_FILE))


### PR DESCRIPTION
parser tidak berada root path ketika run go test ./tests sehingga failed dalam mencari file yang dicari

ini quick solve ketimbang buat env untuk menentukan path lalu di join bla.. bla.. bla..